### PR TITLE
triple quotes for older Python versions

### DIFF
--- a/little_timmy/__main__.py
+++ b/little_timmy/__main__.py
@@ -38,8 +38,8 @@ def main():
         LOGGER.info("no unused vars")
     # filter out vars only declared in galaxy_roles and collections
     for var_name, var_locations in all_declared_vars.items():
-        LOGGER.info(f"{var_name} at {[os.path.relpath(
-            x, directory) for x in var_locations]}\n")
+        LOGGER.info(f"""{var_name} at {[os.path.relpath(
+            x, directory) for x in var_locations]}\n""")
 
     LOGGER.debug("finished")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "little-timmy"
-version = "0.6.1"
+version = "0.6.2"
 description = "Little Timmy will try their best to find those unused Ansible variables."
 readme = "README.md"
 authors = [{ name = "Huw" }]


### PR DESCRIPTION
The PR solves `SyntaxError: EOL while scanning string literal` with older versions of Python.