### PR TITLE
program output to stdout instead stderr

### DIFF
--- a/little_timmy/__main__.py
+++ b/little_timmy/__main__.py
@@ -68,8 +68,8 @@ def main():
         print(output, file=sys.stdout)
     else:
         for var_name, var_locations in all_declared_vars.items():
-            LOGGER.info(f"""{var_name} at {[os.path.relpath(
-                x, directory) for x in var_locations]}\n""")
+            print(f"""{var_name} at {[os.path.relpath(
+                x, directory) for x in var_locations]}\n""", file=sys.stdout)
 
     if args.github_action:
         level = "warning" if args.exit_success else "error"


### PR DESCRIPTION
The program's output should go to stdout, while other messages (info, error) should go to stderr as expected. This change allows me to pipe the output to other commands (e.g., `grep`, `awk`) without anything else from the logger, or without needing to use it like `little-timmy 2>&1|grep foo`.
