### PR TITLE
Skip dynamic inventory files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Change log for the little-timmy python module.
 
+## [2.2.0] - 2025/01/25
+
+- Skip scanning dynamic inventory files because they generate false positives.
+
 ## [2.1.1] - 2024/11/03
 
 - Fix sending non json result output to stdout instead of stderr @leventyalcin

--- a/github_action/Dockerfile
+++ b/github_action/Dockerfile
@@ -11,7 +11,7 @@ LABEL com.github.actions.name="little-timmy-action" \
     org.opencontainers.image.vendor="@hoo29" \
     org.opencontainers.image.description="GHA for Little Timmy, an unused Ansible variable finder."
 
-RUN pip3 install little-timmy==2.1.1
+RUN pip3 install little-timmy==2.2.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/little_timmy/__main__.py
+++ b/little_timmy/__main__.py
@@ -7,7 +7,7 @@ import sys
 from .config_loader import find_and_load_config
 from .var_finder import find_unused_vars
 
-VERSION = "2.1.1"
+VERSION = "2.2.0"
 LOGGER = logging.getLogger("little-timmy")
 
 

--- a/little_timmy/var_finder.py
+++ b/little_timmy/var_finder.py
@@ -133,6 +133,9 @@ def find_unused_vars(directory: str, config: Config) -> dict[str, set[str]]:
         for path in get_items_in_folder(directory, f"{directory}/{inv_folder}/**/*",
                                         config.galaxy_dirs, dirs_to_exclude=config.skip_dirs + ["group_vars", "host_vars", "files", "templates"]):
             LOGGER.debug(f"inv file {path}")
+            if "dynamic" in os.path.basename(path):
+                LOGGER.debug(f"skipping dynamic inventory file {path}")
+                continue
             inventory = InventoryManager(loader=loader, sources=path)
             # groups
             for _, group_value in inventory.groups.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "little-timmy"
-version = "2.1.1"
+version = "2.2.0"
 description = "Little Timmy will try their best to find those unused Ansible variables."
 readme = "README.md"
 authors = [{ name = "Huw" }]


### PR DESCRIPTION
They generate false positives and normally required valid credentials to load