### PR TITLE
consider skip_vars for register, index_var and loop_control

### DIFF
--- a/little_timmy/taml.py
+++ b/little_timmy/taml.py
@@ -86,6 +86,8 @@ def parse_jinja(value: any, source: str, context: Context, jinja_context: bool =
 
 
 def add_declared_var(var_name: str, source: str, context: Context):
+    if skip_var(var_name, context.config.magic_vars, context.config.skip_vars):
+        return
     relative_path = os.path.dirname(os.path.relpath(source, context.root_dir))
     external = any(
         excluded_dir in relative_path for excluded_dir in context.config.dirs_not_to_delcare_vars_from)
@@ -112,8 +114,6 @@ def walk_variable(var_value: any, source: str, context: Context):
 
 
 def parse_yaml_variable(var_name: str, var_value: any, source: str, context: Context):
-    if skip_var(var_name, context.config.magic_vars, context.config.skip_vars):
-        return
     add_declared_var(var_name, source, context)
     walk_variable(var_value, source, context)
 

--- a/tests/repos/config_file_skip/repo/.little-timmy
+++ b/tests/repos/config_file_skip/repo/.little-timmy
@@ -1,2 +1,3 @@
 skip_vars:
   - unused_host_var_b
+  - unused_register_var

--- a/tests/repos/config_file_skip/repo/roles/role1/tasks/main.yml
+++ b/tests/repos/config_file_skip/repo/roles/role1/tasks/main.yml
@@ -26,5 +26,6 @@
     - 1
     - 2
     - 3
+  register: unused_register_var
   loop_control:
     index_var: used_index_var


### PR DESCRIPTION
Hi, I need to skip a register because I’m using this in `molecule`, which is excluded from the `little-timmy` scope. Because of that, I need to `skip_vars`, even if it’s a registered variable.
BTW, I’ve added `index_var` and `loop_control` just in case.